### PR TITLE
feat: add email notification module via Resend API

### DIFF
--- a/backend/src/bindings.d.ts
+++ b/backend/src/bindings.d.ts
@@ -1,0 +1,4 @@
+// Extends the auto-generated CloudflareBindings with secrets not captured by wrangler types
+interface CloudflareBindings {
+  RESEND_API_KEY: string;
+}

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -185,6 +185,17 @@ export async function upsertActionConfig(
   return normalizeActionConfig(row);
 }
 
+export async function updateAuditLogNotified(
+  db: DbClient,
+  auditId: string,
+  notified: boolean,
+) {
+  await db
+    .update(auditLog)
+    .set({ recipientsNotified: notified })
+    .where(eq(auditLog.id, auditId));
+}
+
 export async function createTriggeredActionRecords(
   db: DbClient,
   employeeId: string,

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -10,8 +10,10 @@ import {
   getDocuments,
   listActionConfigs,
   type RequestContext,
+  updateAuditLogNotified,
   upsertActionConfig,
 } from "../db/queries";
+import { dispatchNotification } from "../notifications/dispatchNotification";
 import { resolveEmployeeLifecycleAction } from "../services/actionResolver";
 
 export interface GraphQLContext extends RequestContext {
@@ -168,6 +170,19 @@ const resolvers = {
         args.employeeId,
         args.action,
       );
+
+      const notificationResult = await dispatchNotification({
+        db: context.db,
+        employee: result.employee,
+        document: result.document,
+        action: args.action,
+        apiKey: context.env.RESEND_API_KEY,
+      });
+
+      if (notificationResult.notified) {
+        await updateAuditLogNotified(context.db, result.auditEntry.id, true);
+        result.auditEntry.recipientsNotified = true;
+      }
 
       return {
         employee: result.employee,

--- a/backend/src/notifications/buildEmailTemplate.ts
+++ b/backend/src/notifications/buildEmailTemplate.ts
@@ -1,0 +1,33 @@
+export interface EmailTemplateInput {
+  employeeName: string;
+  employeeCode: string;
+  action: string;
+  documentName: string;
+  documentUrl: string;
+  generatedAt: string;
+}
+
+export interface EmailTemplate {
+  subject: string;
+  text: string;
+}
+
+export function buildEmailTemplate(input: EmailTemplateInput): EmailTemplate {
+  const subject = `[EPAS] ${input.action} — ${input.employeeName} (${input.employeeCode})`;
+
+  const text = [
+    `EPAS Notification`,
+    ``,
+    `Employee: ${input.employeeName}`,
+    `Employee Code: ${input.employeeCode}`,
+    `Action: ${input.action}`,
+    `Generated At: ${input.generatedAt}`,
+    ``,
+    `Document: ${input.documentName}`,
+    `URL: ${input.documentUrl}`,
+    ``,
+    `This is an automated notification from EPAS HR System.`,
+  ].join("\n");
+
+  return { subject, text };
+}

--- a/backend/src/notifications/dispatchNotification.ts
+++ b/backend/src/notifications/dispatchNotification.ts
@@ -1,0 +1,52 @@
+import type { DbClient } from "../db/client";
+import type { Document, Employee } from "../db/schema";
+import { buildEmailTemplate } from "./buildEmailTemplate";
+import { getAllRecipientEmails } from "./resolveRecipients";
+import { sendEmailWithRetry } from "./sendEmailWithRetry";
+
+export interface DispatchNotificationInput {
+  db: DbClient;
+  employee: Employee;
+  document: Document;
+  action: string;
+  apiKey: string;
+}
+
+export interface DispatchNotificationResult {
+  notified: boolean;
+  recipientCount: number;
+  error?: string;
+}
+
+export async function dispatchNotification(
+  input: DispatchNotificationInput,
+): Promise<DispatchNotificationResult> {
+  const emails = await getAllRecipientEmails(input.db);
+
+  if (emails.length === 0) {
+    return { notified: false, recipientCount: 0 };
+  }
+
+  const template = buildEmailTemplate({
+    employeeName: `${input.employee.firstName} ${input.employee.lastName}`,
+    employeeCode: input.employee.employeeCode,
+    action: input.action,
+    documentName: input.document.documentName,
+    documentUrl: input.document.storageUrl,
+    generatedAt: input.document.createdAt,
+  });
+
+  try {
+    await sendEmailWithRetry({
+      to: emails,
+      subject: template.subject,
+      text: template.text,
+      apiKey: input.apiKey,
+    });
+
+    return { notified: true, recipientCount: emails.length };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { notified: false, recipientCount: 0, error };
+  }
+}

--- a/backend/src/notifications/resolveRecipients.ts
+++ b/backend/src/notifications/resolveRecipients.ts
@@ -1,0 +1,20 @@
+import { inArray } from "drizzle-orm";
+
+import type { DbClient } from "../db/client";
+import { recipients } from "../db/schema";
+
+export async function resolveRecipients(db: DbClient, roles: string[]): Promise<string[]> {
+  if (roles.length === 0) return [];
+
+  const rows = await db
+    .select({ email: recipients.email })
+    .from(recipients)
+    .where(inArray(recipients.role, roles));
+
+  return rows.map((r) => r.email);
+}
+
+export async function getAllRecipientEmails(db: DbClient): Promise<string[]> {
+  const rows = await db.select({ email: recipients.email }).from(recipients);
+  return rows.map((r) => r.email);
+}

--- a/backend/src/notifications/sendEmail.ts
+++ b/backend/src/notifications/sendEmail.ts
@@ -1,0 +1,32 @@
+export interface SendEmailInput {
+  to: string[];
+  subject: string;
+  text: string;
+  apiKey: string;
+  fromEmail?: string;
+}
+
+export async function sendEmail(input: SendEmailInput): Promise<void> {
+  if (input.to.length === 0) return;
+
+  const from = input.fromEmail ?? "EPAS HR System <onboarding@resend.dev>";
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Email send failed: ${response.status} ${errorBody}`);
+  }
+}

--- a/backend/src/notifications/sendEmailWithRetry.ts
+++ b/backend/src/notifications/sendEmailWithRetry.ts
@@ -1,0 +1,21 @@
+import { sendEmail, type SendEmailInput } from "./sendEmail";
+
+const MAX_ATTEMPTS = 3;
+
+export async function sendEmailWithRetry(input: SendEmailInput): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      await sendEmail(input);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -40,6 +40,11 @@
    * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
    * Note: Use secrets to store sensitive data.
    * https://developers.cloudflare.com/workers/configuration/secrets/
+   *
+   * RESEND_API_KEY — set as a secret:
+   *   wrangler secret put RESEND_API_KEY
+   * For local dev, create .dev.vars and add:
+   *   RESEND_API_KEY=re_xxxxxxxxxxxx
    */
   // "vars": {  "MY_VARIABLE": "production_value" }
   /**


### PR DESCRIPTION
- Add notifications/ module: resolveRecipients, buildEmailTemplate, sendEmail, sendEmailWithRetry, dispatchNotification
- Wire dispatchNotification into triggerAction GraphQL mutation
- Add updateAuditLogNotified to update audit log after email sent
- Add RESEND_API_KEY type declaration in bindings.d.ts